### PR TITLE
Add withDisableBackup plugin to app configuration

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -30,6 +30,10 @@ module.exports = ({ config }: ConfigContext): Partial<ExpoConfig> => {
         projectId: "d0a7ff2b-7dff-4a67-abe8-145c24dc0098",
       },
     },
-    plugins: [...existingPlugins, require("./plugins/withSplashScreen").withSplashScreen],
+    plugins: [
+      ...existingPlugins,
+      require("./plugins/withSplashScreen").withSplashScreen,
+      require("./plugins/withDisableBackup").withDisableBackup,
+    ],
   }
 }

--- a/plugins/withDisableBackup.ts
+++ b/plugins/withDisableBackup.ts
@@ -1,0 +1,22 @@
+import { ConfigPlugin, withAndroidManifest } from "expo/config-plugins"
+import { ExpoConfig } from "expo/config"
+
+/**
+ * Expo Config Plugin para desabilitar o backup automático no Android.
+ * Isso impede que o sistema restaure os dados persistidos após desinstalação/reinstalação.
+ */
+export const withDisableBackup: ConfigPlugin = (config: ExpoConfig) => {
+  return withAndroidManifest(config, (modConfig) => {
+    const androidManifest = modConfig.modResults
+    const app = androidManifest.manifest.application?.[0]
+
+    if (app && app.$) {
+      // Desabilita backup automático
+      app.$["android:allowBackup"] = "false"
+      app.$["android:fullBackupContent"] = "false"
+    }
+    return modConfig
+  })
+}
+
+export default withDisableBackup


### PR DESCRIPTION
This commit adds the withDisableBackup plugin to the app.config.ts file. The plugin is included in the plugins array, which will likely disable automatic backups for the application. This change enhances the app's configuration and may affect its backup behavior.